### PR TITLE
users.identity fallsback when auth.test fails

### DIFF
--- a/slack_server.js
+++ b/slack_server.js
@@ -68,7 +68,24 @@ var getIdentity = function (accessToken) {
       "https://slack.com/api/auth.test",
       {params: {token: accessToken}});
 
-    return response.data.ok && response.data;
+    if (response.data && response.data.ok)
+      return response.data;
+
+    response = HTTP.get(
+      "https://slack.com/api/users.identity",
+      {params: {token: accessToken}});
+
+    if (response.data && response.data.ok)
+      // Simulate the response that auth.test would have returned
+      return _.extend(response.data.user, {
+        user: response.data.user.name,
+        user_id: response.data.user.id,
+        team_id: response.data.team.id,
+        team: response.data.team.name,
+        url: response.data.url
+      });
+    else
+      throw new Error("Could not retrieve user identity");
   } catch (err) {
     throw _.extend(new Error("Failed to fetch identity from Slack. " + err.message),
                    {response: err.response});


### PR DESCRIPTION
- It happens that, when users try to "Sign in with Slack" but haven't added
  their app to slack first, `auth.test` tends to return `invalid_token`. The
  slack API documentation talks about a recently introduced `users.identity`
  API call that provides the caller with enough information to keep going.

- The previous behavior was to return `false`, which causes the oAuth code
  not to report the error and instead to insert an object with only nulls.
  Instead, this code raises an exception so that the login process fails,
  which makes it easier to debug.