### PR TITLE
fixes bot token bug according to new slack api spec

### DIFF
--- a/slack_server.js
+++ b/slack_server.js
@@ -11,7 +11,8 @@ OAuth.registerService('slack', 2, null, function(query) {
     serviceData: {
       id: identity.user_id,
       accessToken: tokens.access_token,
-      botAccessToken: tokens.bot_access_token
+      botAccessToken: tokens.bot.bot_access_token,
+      botUserId: tokens.bot.bot_user_id
     },
     options: {
       profile: {


### PR DESCRIPTION
The `botAccessToken` now lives under `bot` property according to new slack api spec. This commit retrieves the token from the correct property.