### PR TITLE
Migrate a legacy Sign in With Slack app

### DIFF
--- a/slack_client.js
+++ b/slack_client.js
@@ -31,7 +31,7 @@ Slack.requestCredential = function (options, credentialRequestCompleteCallback) 
   var loginStyle = OAuth._loginStyle('slack', config, options);
 
   var loginUrl =
-        'https://slack.com/oauth/authorize' +
+        'https://slack.com/openid/connect/authorize' +
         '?client_id=' + config.clientId +
         '&response_type=code' +
         '&scope=' + flatScope +

--- a/slack_server.js
+++ b/slack_server.js
@@ -78,6 +78,7 @@ var getIdentity = function (accessToken) {
     response = HTTP.get(
       "https://slack.com/api/openid.connect.userInfo",
       {params: {token: accessToken}});
+    
     if (response.data && response.data.ok) {
       // Replace response object key names including 'https://slack.com/' string
       replaceObjectKeyName(response.data);


### PR DESCRIPTION
New and improved Sign With Slack is based on [OpenID Connect standard](https://openid.net/specs/openid-connect-core-1_0.html).

Therefore following changes are necessary to migrate the meteor applications using Sign In With Slack:

- The authorization endpoint becomes `/openid/connect/authorize`, rather than `/oauth/v2/authorize` or `/oauth/authorize`.
- Exchange access code for an access token using an OpenID endpoint, [openid.connect.token](https://api.slack.com/methods/openid.connect.token)
- The [users.info](https://api.slack.com/methods/users.info) method becomes the [openid.connect.userInfo](https://api.slack.com/methods/openid.connect.userInfo) method.

Slack Sign In With Slack Migration steps: [migrate a legacy sign in with slack app](https://github.com/acemtp/meteor-accounts-slack/commit/7ec350b835c04694fb0c8eb2e76eed68d06a0ead)